### PR TITLE
MultipleFileAttachmentField problem when attaching multiple images to an object.

### DIFF
--- a/code/ManyManySortable.php
+++ b/code/ManyManySortable.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Adds many_many sortable to a relationship
+ * Add the following example to your _config with the 
+ * The key of the array is the Object that has the many_many relationship set on it.
+ * The value is another array in which the 1st element is the Relationship name and the 2nd element is the sort order.
+ *
+ *	Example: ManyManySortable::add_sortable_many_many_relations(array('ParentManyMany' => 'Relationship'));
+ * 
+ * The idea here is that the DataObject that has the many_many relationship is decorated. This way we can add the sorting 
+ * to the relationship table and not add anyting to the sorted DataObject since this needs to work with File and Image objects
+ * instead of creating a new DataObject that has the File as a has_one and decorating that object the way SortableDataObject works.
+ * 
+ * The method ManyManySorted() can be used on the many_many Parent object to get the related Files or Images in the correct order
+ * as set in the database in the ManyManySort column.
+ * 
+ * @package KickAssets
+ * @author UncleCheese <unclecheese@leftandmain.com>
+ * @author Micah Sheets <micah@soniceyetec.biz>
+ */
+
+class ManyManySortable extends DataObjectDecorator {
+	
+	static $many_many_sortable_relations = array();
+	static $sort_dir = "ASC";
+	
+	public static function set_sort_dir($dir) {
+		self::$sort_dir = $dir;
+	}
+	
+	/**
+	 * Used in _config to set up any many_many sortable relationships.
+	 * 
+	 * @param array where $key is the DataObject with the many_many relationships set on it 
+	 * 			and the $value is the name of the relationship.
+	 */
+	public static function add_sortable_many_many_relations(array $classes) {
+		foreach($classes as $id => $value)
+			$ownerClass = $id;
+			$componentName = $value;
+			DataObject::add_extension($ownerClass,'ManyManySortable');
+			self::add_sortable_many_many_relation($ownerClass,$componentName);
+	}
+	
+	/**
+	 * Adds the ManyManySort column in the database table for the relationship.
+	 * Adds the parent many_many and relation name to $many_many_sortable_relations so
+	 * they can be used in ManyManySorted()
+	 * 
+	 * @param DataObject with many_many
+	 * @param Relationship name
+	 */
+	public static function add_sortable_many_many_relation($ownerClass,$componentName) {
+	    Object::add_static_var($ownerClass,'many_many_extraFields',array(
+	      $componentName => array(
+	        'ManyManySort' => 'Int'
+	     )));
+		 self::$many_many_sortable_relations[$ownerClass]['relationName'] = $componentName;
+	}
+	
+	/**
+	 * Used in decorated classes to access the ManyManySorted objects.
+	 * 
+	 * @param string either 'ASC' or 'DESC'
+	 * 
+	 */
+	function ManyManySorted($sortdir = null) {
+		$sortDirection = ($sortdir) ? $sortdir : self::$sort_dir;
+		$functionname = self::$many_many_sortable_relations[$this->owner->ClassName]['relationName'];
+		return $this->owner->$functionname(null, 'ManyManySort '.$sortDirection);
+	}
+}

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -61,7 +61,12 @@ class MultipleFileAttachmentField extends KickAssetField {
 		if($r->requestVar('ids')) {
 			$ids = array_unique($r->requestVar('ids'));
 			$files = new DataObjectSet();
-			if($set = DataObject::get("File", "\"File\".ID IN (".implode(',',$ids).")")) {
+			// Added to fix problem whee sometimes and even often a comma is put in the fron of the string 
+			// when implode is run on $ids. Uses a regular express that should leave things along if 
+			// there is no preceeding coma. The coma breaks the sql if left in.
+			$implodestring = implode(',',$ids);
+			$implodestring = preg_replace("/^[,]/", "", $implodestring);
+			if($set = DataObject::get("File", "`ID` IN ($implodestring)")) {
 				foreach($set as $file) {
 					$this->processFile($file);
 					$files->push($file);					

--- a/javascript/manymanysortable.js
+++ b/javascript/manymanysortable.js
@@ -1,0 +1,26 @@
+jQuery(document).ready(function(){
+	
+	/**
+	 * Sort Fields in the Field List
+	 */
+	jQuery("#sortable").livequery(function(){
+		
+		jQuery(this).sortable({
+			handle : '.fieldHandler',
+			items: 'li.sortableli',
+			opacity: 0.6,
+			revert: true,
+			change : function (event, ui) {
+				jQuery("#sortable").sortable('refreshPositions');
+			},
+	    	update : function (event, ui) {
+	      		// get all the fields
+				var sort = 1;
+				jQuery("li.sortableli").each(function() {
+					jQuery(this).find(".sortHidden").val(sort++);
+				});
+	    	}
+		});
+	});
+
+});

--- a/templates/Includes/KickAssetFieldFiles_Multi.ss
+++ b/templates/Includes/KickAssetFieldFiles_Multi.ss
@@ -6,8 +6,11 @@
 
 	<div class="file_name">
 	<% if Files %>
+		<ul id="sortable">
 		<% control Files %>
+		<li class="sortableli" style="cursor: default;">
 			<div class="file_block">
+				<img class="fieldHandler" alt="Drag to rearrange order of fields" src="sapphire/images/drag.gif" style="cursor: move;">
 				<span class="thumb"><img src="$Thumb" height="24" /></span> <span class="name">$Name</span> <span class="size">($Size)</span>
 				<span class="multi_actions">
 				<a href="$EditLink" class="file_attach_btn" data-id="$ID" title="<% _t('FileAttachmentField.EDIT','Edit') %>"><img src="kickassets/images/edit.png" height="14" /></a>
@@ -15,8 +18,11 @@
 				<a href="$RemoveLink" class="delete_btn" data-confirmtext="<% _t('FileAttachmentField.AREYOUSURE','Are you sure you want to delete this file permanently?') %>"	 data-id="$ID" title="<% _t('FileAttachmentField.DELETEPERMANENTLY','Delete permanently') %>"><img src="kickassets/images/delete.png" height="14" /></a>
 				</span>
 				<input type="hidden" name="{$Top.Name}[]" value="$ID" />
+				<input type="hidden" class="sortHidden" name="sort[]" value="$POS" />
 			</div>
+		</li>
 		<% end_control %>
+		</ul>
 	<% else %>
 		<% _t('FileAttachmentField.NOFILESATTACHED','No files attached') %>
 	<% end_if %>


### PR DESCRIPTION
Added code to function refresh() in MultipleFileAttachmentField.php to fix problem when a coma is put in the front of the string when implode is run on $ids. Uses a regular express that should leave things along if there is no preceding coma. The coma breaks the sql if left in.
