### PR TITLE
Patch to fix issues with Uploading files with MultipleFileAttachmentField

### DIFF
--- a/code/ManyManySortable.php
+++ b/code/ManyManySortable.php
@@ -23,11 +23,6 @@
 class ManyManySortable extends DataObjectDecorator {
 	
 	static $many_many_sortable_relations = array();
-	static $sort_dir = "ASC";
-	
-	public static function set_sort_dir($dir) {
-		self::$sort_dir = $dir;
-	}
 	
 	/**
 	 * Used in _config to set up any many_many sortable relationships.
@@ -61,13 +56,9 @@ class ManyManySortable extends DataObjectDecorator {
 	
 	/**
 	 * Used in decorated classes to access the ManyManySorted objects.
-	 * 
-	 * @param string either 'ASC' or 'DESC'
-	 * 
 	 */
-	function ManyManySorted($sortdir = null) {
-		$sortDirection = ($sortdir) ? $sortdir : self::$sort_dir;
+	function ManyManySorted() {
 		$functionname = self::$many_many_sortable_relations[$this->owner->ClassName]['relationName'];
-		return $this->owner->$functionname(null, 'ManyManySort '.$sortDirection);
+		return $this->owner->$functionname(null, 'ManyManySort ASC'); // Sort order must not be changed or MultipleFileAttachmentField will no longer work properly.
 	}
 }

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -3,6 +3,9 @@
  * Provides an interface for attaching multiple files associated with
  * a Page or DataObject. Files can be chosen from exting assets in {@link KickAssetAdmin}
  *
+ * To allow files managed using this interface to be sorted you must add the ManyManySortable Decorator to
+ * the DataObject that the relation ship is set on. See ManyManySortable.php for more information on how to do this.
+ *
  * @package KickAssets
  * @author UncleCheese <unclecheese@leftandmain.com>
  */

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -8,8 +8,6 @@
  */
 
 class MultipleFileAttachmentField extends KickAssetField {
-
-
 	
 	/**
 	 * @var boolean A simple template variable that states whether this is a multiple

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -3,9 +3,6 @@
  * Provides an interface for attaching multiple files associated with
  * a Page or DataObject. Files can be chosen from exting assets in {@link KickAssetAdmin}
  *
- * To allow files managed using this interface to be sorted you must add the ManyManySortable Decorator to
- * the DataObject that the relation ship is set on. See ManyManySortable.php for more information on how to do this.
- *
  * @package KickAssets
  * @author UncleCheese <unclecheese@leftandmain.com>
  */
@@ -153,16 +150,19 @@ class MultipleFileAttachmentField extends KickAssetField {
 			if($relation_name = $this->getForeignRelationName($record)) {
 				// Assign all the new relations (may have already existed)
 				$data = $_REQUEST;
-				//Debug::show($data);
 				for($count = 0; $count < count($data[$this->name]); ++$count) {
 					$id = $data[$this->name][$count];
 					if($file = DataObject::get_by_id("File", $id)) {
 						$new = ($file_class != "File") ? $file->newClassInstance($file_class) : $file;
+						$new->write();
 						if ($this->isSortable()){
 							$sort = $data['sort'][$count];
 							$currentComponentSet->add($new, array('ManyManySort'=>$sort));
 						}
-						$new->write();
+						else {
+							$currentComponentSet->add($new);
+						}
+						
 					}
 				}
 			}

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -105,12 +105,13 @@ class MultipleFileAttachmentField extends KickAssetField {
 			if(is_array($val)) {
 				$list = implode(',', $val);
 				
-				if ($this->isSortable()) {
+				if ($many_many_parent->hasExtension('ManyManySortable') && method_exists($many_many_parent, "ManyManySorted")) {
 					$files = $many_many_parent->ManyManySorted();
 				}
 				else {
 					$files = DataObject::get("File", "\"File\".\"ID\" IN (".Convert::raw2sql($list).")");
 				}
+				$files = DataObject::get("File", "\"File\".\"ID\" IN (".Convert::raw2sql($list).")");
 				if($files->Count() > 0) {
 					$ret = new DataObjectSet();
 					foreach($files as $file) {
@@ -148,8 +149,10 @@ class MultipleFileAttachmentField extends KickAssetField {
 
 		if(isset($_REQUEST[$this->name]) && is_array($_REQUEST[$this->name])) {
 			if($relation_name = $this->getForeignRelationName($record)) {
+
 				// Assign all the new relations (may have already existed)
 				$data = $_REQUEST;
+
 				for($count = 0; $count < count($data[$this->name]); ++$count) {
 					$id = $data[$this->name][$count];
 					if($file = DataObject::get_by_id("File", $id)) {
@@ -162,7 +165,6 @@ class MultipleFileAttachmentField extends KickAssetField {
 						else {
 							$currentComponentSet->add($new);
 						}
-						
 					}
 				}
 			}

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -105,13 +105,12 @@ class MultipleFileAttachmentField extends KickAssetField {
 			if(is_array($val)) {
 				$list = implode(',', $val);
 				
-				if ($many_many_parent->hasExtension('ManyManySortable') && method_exists($many_many_parent, "ManyManySorted")) {
+				if ($this->isSortable()) {
 					$files = $many_many_parent->ManyManySorted();
 				}
 				else {
 					$files = DataObject::get("File", "\"File\".\"ID\" IN (".Convert::raw2sql($list).")");
 				}
-				$files = DataObject::get("File", "\"File\".\"ID\" IN (".Convert::raw2sql($list).")");
 				if($files->Count() > 0) {
 					$ret = new DataObjectSet();
 					foreach($files as $file) {
@@ -151,15 +150,16 @@ class MultipleFileAttachmentField extends KickAssetField {
 			if($relation_name = $this->getForeignRelationName($record)) {
 				// Assign all the new relations (may have already existed)
 				$data = $_REQUEST;
+				//Debug::show($data);
 				for($count = 0; $count < count($data[$this->name]); ++$count) {
 					$id = $data[$this->name][$count];
 					if($file = DataObject::get_by_id("File", $id)) {
 						$new = ($file_class != "File") ? $file->newClassInstance($file_class) : $file;
-						$new->write();
 						if ($this->isSortable()){
 							$sort = $data['sort'][$count];
 							$currentComponentSet->add($new, array('ManyManySort'=>$sort));
 						}
+						$new->write();
 					}
 				}
 			}

--- a/templates/Includes/KickAssetFieldFiles_Multi.ss
+++ b/templates/Includes/KickAssetFieldFiles_Multi.ss
@@ -5,24 +5,43 @@
 <div class="file_info">
 
 	<div class="file_name">
+	
 	<% if Files %>
-		<ul id="sortable">
-		<% control Files %>
-		<li class="sortableli" style="cursor: default;">
-			<div class="file_block">
-				<img class="fieldHandler" alt="Drag to rearrange order of fields" src="sapphire/images/drag.gif" style="cursor: move;">
-				<span class="thumb"><img src="$Thumb" height="24" /></span> <span class="name">$Name</span> <span class="size">($Size)</span>
-				<span class="multi_actions">
-				<a href="$EditLink" class="file_attach_btn" data-id="$ID" title="<% _t('FileAttachmentField.EDIT','Edit') %>"><img src="kickassets/images/edit.png" height="14" /></a>
-				<a href="javascript:void(0);" class="detach_btn" data-id="$ID" title="<% _t('FileAttachmentField.DETACH','Detach') %>"><img src="kickassets/images/remove.png" height="14" /></a>
-				<a href="$RemoveLink" class="delete_btn" data-confirmtext="<% _t('FileAttachmentField.AREYOUSURE','Are you sure you want to delete this file permanently?') %>"	 data-id="$ID" title="<% _t('FileAttachmentField.DELETEPERMANENTLY','Delete permanently') %>"><img src="kickassets/images/delete.png" height="14" /></a>
-				</span>
-				<input type="hidden" name="{$Top.Name}[]" value="$ID" />
-				<input type="hidden" class="sortHidden" name="sort[]" value="$POS" />
-			</div>
-		</li>
-		<% end_control %>
-		</ul>
+		<% if isSortable %>
+			<ul id="sortable">
+				<% control Files %>
+					<li class="sortableli" style="cursor: default;">
+						<div class="file_block">
+							<img class="fieldHandler" alt="Drag to rearrange order of fields" src="sapphire/images/drag.gif" style="cursor: move;">
+							<span class="thumb"><img src="$Thumb" height="24" /></span> <span class="name">$Name</span> <span class="size">($Size)</span>
+							<span class="multi_actions">
+							<a href="$EditLink" class="file_attach_btn" data-id="$ID" title="<% _t('FileAttachmentField.EDIT','Edit') %>"><img src="kickassets/images/edit.png" height="14" /></a>
+							<a href="javascript:void(0);" class="detach_btn" data-id="$ID" title="<% _t('FileAttachmentField.DETACH','Detach') %>"><img src="kickassets/images/remove.png" height="14" /></a>
+							<a href="$RemoveLink" class="delete_btn" data-confirmtext="<% _t('FileAttachmentField.AREYOUSURE','Are you sure you want to delete this file permanently?') %>"	 data-id="$ID" title="<% _t('FileAttachmentField.DELETEPERMANENTLY','Delete permanently') %>"><img src="kickassets/images/delete.png" height="14" /></a>
+							</span>
+							<input type="hidden" name="{$Top.Name}[]" value="$ID" />
+							<input type="hidden" class="sortHidden" name="sort[]" value="$POS" />
+						</div>
+					</li>
+				<% end_control %>
+			</ul>
+		<% else %>
+			<ul>
+			<% control Files %>
+				<li>
+					<div class="file_block">
+						<span class="thumb"><img src="$Thumb" height="24" /></span> <span class="name">$Name</span> <span class="size">($Size)</span>
+						<span class="multi_actions">
+							<a href="$EditLink" class="file_attach_btn" data-id="$ID" title="<% _t('FileAttachmentField.EDIT','Edit') %>"><img src="kickassets/images/edit.png" height="14" /></a>
+							<a href="javascript:void(0);" class="detach_btn" data-id="$ID" title="<% _t('FileAttachmentField.DETACH','Detach') %>"><img src="kickassets/images/remove.png" height="14" /></a>
+							<a href="$RemoveLink" class="delete_btn" data-confirmtext="<% _t('FileAttachmentField.AREYOUSURE','Are you sure you want to delete this file permanently?') %>"	 data-id="$ID" title="<% _t('FileAttachmentField.DELETEPERMANENTLY','Delete permanently') %>"><img src="kickassets/images/delete.png" height="14" /></a>
+						</span>
+						<input type="hidden" name="{$Top.Name}[]" value="$ID" />
+					</div>
+				</li>
+				<% end_control %>
+			</ul>
+		<% end_if %>
 	<% else %>
 		<% _t('FileAttachmentField.NOFILESATTACHED','No files attached') %>
 	<% end_if %>


### PR DESCRIPTION
This patch allows for the field to work normally if the file relationship class has not been set to use ManyManySortable via _config.php with:
[code]
ManyManySortable::add_sortable_many_many_relations(array('Class' => 'RelationName'));
[\code]

This patch also fixes issues that were causing errors when uploading using "From your computer".

NOTE: The Drag and Drop feature is still not functioning.
