### PR TITLE
Bugfix branch

### DIFF
--- a/code/KickAssetAdmin.php
+++ b/code/KickAssetAdmin.php
@@ -285,6 +285,10 @@ class KickAssetAdmin extends LeftAndMain implements PermissionProvider {
 	 */
 	public function updatefilename(SS_HTTPRequest $r) {
 		if($file = DataObject::get_by_id("File", (int) $r->requestVar('fileid'))) {
+			if ($file->Title == $file->Name) {
+				// Make sure title also changes, if old title was same as old Name.
+				$file->Title = $r->requestVar('new');
+			}
 			$file->setName($r->requestVar('new'));
 			$file->write();
 			$template = $file instanceof Folder ? "Folder" : "File";

--- a/templates/Includes/KickAssetFieldFiles.ss
+++ b/templates/Includes/KickAssetFieldFiles.ss
@@ -2,7 +2,7 @@
 <div class="file_drop <% if File %><% else %>empty<% end_if %>" data-uploadurl="$UploadLink"
 	<% if File %>
 		<% control File %>
-		style="background-image:url($Thumb)"
+		style="background-image:url('$Thumb')"
 		<% end_control %>
 	<% end_if %>					
 >


### PR DESCRIPTION
Hi there, a couple of minor fixes here.

Renaming of files didn't update the Title attribute, which means they later show up with the old name in TreeDropdownList etc.  Here I change the title, only if the old title was same as old name, hence preserving any customisations made to Title separately.

Plus, images with a space in the name weren't showing up in the attachment field correctly.

Kickassets has a lot of promise, it's a great module.

Cheers, - Luke
