### PR TITLE
IE8 page not found when you double click on a folder. 

### DIFF
--- a/javascript/kickassets.js
+++ b/javascript/kickassets.js
@@ -398,7 +398,7 @@ $(document).ready(function() {
 	$('.folder img, .grid .folder').live('dblclick', function(e) {
 		if($(e.target).is('.editable')) return;
 		var $t = $(this).closest('li');
-		window.location.href = $t.data('link');
+		window.location.href = $('base').attr('href') + $t.data('link');
 		return false;
 	});
 	


### PR DESCRIPTION
url gets concatenated in ie8, so just added the base url. 
