### PR TITLE
BUGFIX: fixes sort order of newly uploaded & attached files #43

### DIFF
--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -67,7 +67,8 @@ class MultipleFileAttachmentField extends KickAssetField {
 	public function refresh(SS_HTTPRequest $r) {
 		if($r->requestVar('ids')) {
 			$ids = array_unique($r->requestVar('ids'));
-			$files = new DataObjectSet();
+			$files = $this->Files();
+			if(!$files) $files = new DataObjectSet();
 			$implodestring = implode(',',$ids);
 			$implodestring = preg_replace("/^[,]/", "", $implodestring);
 			if($set = DataObject::get("File", "`ID` IN ($implodestring)")) {
@@ -75,7 +76,6 @@ class MultipleFileAttachmentField extends KickAssetField {
 					$this->processFile($file);
 					$files->push($file);					
 				}
-				$files->merge($this->Files());
 				$files->removeDuplicates();
 			}
 			else {

--- a/code/MultipleFileAttachmentField.php
+++ b/code/MultipleFileAttachmentField.php
@@ -71,7 +71,7 @@ class MultipleFileAttachmentField extends KickAssetField {
 			if(!$files) $files = new DataObjectSet();
 			$implodestring = implode(',',$ids);
 			$implodestring = preg_replace("/^[,]/", "", $implodestring);
-			if($set = DataObject::get("File", "`ID` IN ($implodestring)")) {
+			if($set = DataObject::get("File", "`ID` IN ($implodestring)", "ID ASC")) {
 				foreach($set as $file) {
 					$this->processFile($file);
 					$files->push($file);					


### PR DESCRIPTION
When new files are uploaded and attached via the 'From your computer' button the new files were pushed to the top of the stack resulting in the sort order being messed up, this doesn't happen when attaching files that are already uploaded.

Believe this should fix bug #43
